### PR TITLE
Include gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,34 @@
+# Sensitive environment variables
+environment*
+
+# Snakemake state dir
+.snakemake
+
+# Local config overrides
+/config_local.yaml
+
+# For Python #
+##############
+*.pyc
+.tox/
+.cache/
+
+# Compiled source #
+###################
+*.com
+*.class
+*.dll
+*.exe
+*.o
+*.so
+
+# OS generated files #
+######################
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+Icon?
+ehthumbs.db
+Thumbs.db


### PR DESCRIPTION
@pauloluniyi ---

`.gitignore` helps keep extraneous files out of GitHub and is generally a useful thing to have. This ignores things like `.snakemake` and `.DS_Store` that don't need to be in the repo.